### PR TITLE
Update SR.cs

### DIFF
--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/SR.cs
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/SR.cs
@@ -289,7 +289,7 @@ namespace System
 
         internal SR()
         {
-            this.resources = new ResourceManager("System.Core", this.GetType().Assembly);
+            this.resources = new ResourceManager("System.IO.Pipes.System.Core", this.GetType().Assembly);
         }
 
         private static SR GetLoader()


### PR DESCRIPTION
Fixes an issue where an exception is thrown while trying to build the exception text when a error occurs setting up the pipe.

During the resource embedding process, the c# compiler prepends the default namespace of the project to the `System.Core.resources` file. This results in the file being embedded with the name `System.IO.Pipes.System.Core.resources`

![image](https://user-images.githubusercontent.com/17229877/152471769-8e4c189a-6efa-4f89-ba84-f531eec316f8.png)

However, in the `SR.cs` file, it attempts to load `System.Core.resources` which results in a `System.Resources.MissingManifestResourceException` exception whenever a message lookup is performed. As a result, the true exception is hidden and swallowed. 


