### PR TITLE
Forward to the official implementation if available.

### DIFF
--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStream.NetFrameworkVersion.csproj
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStream.NetFrameworkVersion.csproj
@@ -34,12 +34,6 @@ Features:
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStream.NetFrameworkVersion.csproj
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStream.NetFrameworkVersion.csproj
@@ -5,7 +5,7 @@
     <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>System.IO.Pipes</RootNamespace>
-    <NoWarn>$(NoWarn);CA1508;CA1838;CA2251;CA5392;CA1845;SYSLIB0003</NoWarn>
+    <NoWarn>$(NoWarn);CA1508;CA1838;CA2251;CA5392;CA1845;CA2101;SYSLIB0003</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet">

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStream.NetFrameworkVersion.csproj
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStream.NetFrameworkVersion.csproj
@@ -22,7 +22,7 @@ Features:
     <PackageTags>NamedPipeServerStream, pipes, named pipes, async, async named pipes, namedpipes async, namedpipes, pipes async</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Label="Resources">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Resources">
     <None Remove="System.Core.resources" />
     <EmbeddedResource Include="System.Core.resources" />
   </ItemGroup>

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStreamConstructors.cs
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStreamConstructors.cs
@@ -18,7 +18,7 @@ public static class NamedPipeServerStreamConstructors
 {
 #if NETFRAMEWORK
     /// <inheritdoc cref="NamedPipeServerStream(string, PipeDirection, int, PipeTransmissionMode, PipeOptions, int, int, PipeSecurity, HandleInheritability, PipeAccessRights)"/>
-#elif NET6_0_OR_GREATER
+#elif NET5_0_OR_GREATER
 /// <inheritdoc cref="NamedPipeServerStreamAcl.Create"/>
 #else
     /// <summary>

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStreamConstructors.cs
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStreamConstructors.cs
@@ -1,6 +1,9 @@
 ﻿using System.Globalization;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
 using System.Security;
 using System.Security.Permissions;
 using System.Text;
@@ -13,6 +16,11 @@ namespace System.IO.Pipes;
 [SecurityCritical]
 public static class NamedPipeServerStreamConstructors
 {
+#if NETFRAMEWORK
+    /// <inheritdoc cref="NamedPipeServerStream(string, PipeDirection, int, PipeTransmissionMode, PipeOptions, int, int, PipeSecurity, HandleInheritability, PipeAccessRights)"/>
+#elif NET6_0_OR_GREATER
+/// <inheritdoc cref="NamedPipeServerStreamAcl.Create"/>
+#else
     /// <summary>
     /// Create a new <see cref="NamedPipeServerStream"/>. All default parameters are copied from the original constructors.
     /// </summary>
@@ -27,11 +35,9 @@ public static class NamedPipeServerStreamConstructors
     /// <param name="inheritability"></param>
     /// <param name="additionalAccessRights"></param>
     /// <returns></returns>
+#endif
 #if NET5_0_OR_GREATER
-[System.Runtime.Versioning.SupportedOSPlatform("windows")]
-#elif NETSTANDARD2_0_OR_GREATER || NET40_OR_GREATER
-#else
-#error Target Framework is not supported
+    [SupportedOSPlatform("windows")]
 #endif
     [SecurityCritical]
     public static NamedPipeServerStream New(
@@ -46,6 +52,13 @@ public static class NamedPipeServerStreamConstructors
         HandleInheritability inheritability = HandleInheritability.None,
         PipeAccessRights additionalAccessRights = 0)
     {
+#if NETFRAMEWORK
+        return new NamedPipeServerStream(pipeName, direction, maxNumberOfServerInstances, transmissionMode,
+            options, inBufferSize, outBufferSize, pipeSecurity, inheritability, additionalAccessRights);
+#elif NET5_0_OR_GREATER
+        return NamedPipeServerStreamAcl.Create(pipeName, direction, maxNumberOfServerInstances, transmissionMode,
+            options, inBufferSize, outBufferSize, pipeSecurity, inheritability, additionalAccessRights);
+#else
         switch (pipeName)
         {
             case "":
@@ -90,8 +103,10 @@ public static class NamedPipeServerStreamConstructors
                         ((GCHandle)pinningHandle).Free();
                 }
         }
+#endif
     }
 
+#if NETSTANDARD2_0
     [SecurityCritical]
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true, BestFitMapping = false)]
     internal static extern SafePipeHandle CreateNamedPipe(
@@ -104,12 +119,6 @@ public static class NamedPipeServerStreamConstructors
         int defaultTimeout,
         SECURITY_ATTRIBUTES securityAttributes);
 
-#if NET5_0_OR_GREATER
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-#elif NETSTANDARD2_0_OR_GREATER || NET40_OR_GREATER
-#else
-#error Target Framework is not supported
-#endif
     [SecurityCritical]
     internal static unsafe SECURITY_ATTRIBUTES GetSecAttrs(
         HandleInheritability inheritability,
@@ -121,11 +130,7 @@ public static class NamedPipeServerStreamConstructors
         if ((inheritability & HandleInheritability.Inheritable) != HandleInheritability.None || pipeSecurity != null)
         {
             securityAttributes = new SECURITY_ATTRIBUTES();
-#if NET5_0_OR_GREATER
             securityAttributes.nLength = Marshal.SizeOf<SECURITY_ATTRIBUTES>();
-#else
-            securityAttributes.nLength = Marshal.SizeOf((object)securityAttributes);
-#endif
             if ((inheritability & HandleInheritability.Inheritable) != HandleInheritability.None)
                 securityAttributes.bInheritHandle = 1;
             if (pipeSecurity != null)
@@ -261,4 +266,5 @@ public static class NamedPipeServerStreamConstructors
         StringBuilder lpBuffer = new StringBuilder(512);
         return FormatMessage(12800, NULL, errorCode, 0, lpBuffer, lpBuffer.Capacity, NULL) != 0 ? lpBuffer.ToString() : "UnknownError_Num " + (object)errorCode;
     }
+#endif
 }

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStreamConstructors.cs
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/NamedPipeServerStreamConstructors.cs
@@ -1,12 +1,11 @@
-﻿using System.Globalization;
+﻿using System.Security;
+#if NETSTANDARD2_0
+using System.Globalization;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
-#if NET5_0_OR_GREATER
-using System.Runtime.Versioning;
-#endif
-using System.Security;
 using System.Security.Permissions;
 using System.Text;
+#endif
 
 namespace System.IO.Pipes;
 
@@ -37,7 +36,7 @@ public static class NamedPipeServerStreamConstructors
     /// <returns></returns>
 #endif
 #if NET5_0_OR_GREATER
-    [SupportedOSPlatform("windows")]
+    [Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     [SecurityCritical]
     public static NamedPipeServerStream New(

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/SECURITY_ATTRIBUTES.cs
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/SECURITY_ATTRIBUTES.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿#if NETSTANDARD2_0
+using System.Runtime.InteropServices;
 using System.Security;
 
 namespace System.IO.Pipes;
@@ -11,3 +12,4 @@ internal class SECURITY_ATTRIBUTES
     internal unsafe byte* pSecurityDescriptor;
     internal int bInheritHandle;
 }
+#endif

--- a/src/libs/NamedPipeServerStream.NetFrameworkVersion/SR.cs
+++ b/src/libs/NamedPipeServerStream.NetFrameworkVersion/SR.cs
@@ -4,6 +4,7 @@
 // MVID: 95B4B630-A4AF-4E9A-8336-D9E36310DACA
 // Assembly location: C:\Windows\Microsoft.NET\Framework\v4.0.30319\System.Core.dll
 
+#if NETSTANDARD2_0
 using System.Globalization;
 using System.Resources;
 using System.Threading;
@@ -346,3 +347,4 @@ internal sealed class SR
         return SR.GetLoader()?.resources.GetObject(name, SR.Culture);
     }
 }
+#endif


### PR DESCRIPTION
This PR changes the implementation of the library so that when targeting .NET Framework or .NET 6+, we just forward to the framework-provided implementation (that `NamedPipeServerStream` constructor on .NET Framework and `NamedPipeServerStreamAcl.Create` on .NET 6+). It is a much more maintainable solution.

I also removed support for .NET 5 which is unsupported, and removed two unnecessary .NET 6 dependencies.